### PR TITLE
Add card link to VSCode extension to various relevant places in the docs

### DIFF
--- a/components/architect-yml.mdx
+++ b/components/architect-yml.mdx
@@ -5,6 +5,11 @@ description:
   Architect Components. "
 ---
 
+<Card
+  title="For users of Visual Studio Code, check out the Architect.io extension!"
+  href="https://marketplace.visualstudio.com/items?itemName=Architectio.architect-vscode"
+/>
+
 Components described using this syntax can leverage the CLI and Kubernetes
 cluster to provision and update production-grade environments on-demand or via
 automation.

--- a/getting-started/introduction.mdx
+++ b/getting-started/introduction.mdx
@@ -71,6 +71,11 @@ $ architect link ./examples/react-app/
 
 ### Check out the architect.yml file
 
+<Card
+  title="For users of Visual Studio Code, check out the Architect.io extension!"
+  href="https://marketplace.visualstudio.com/items?itemName=Architectio.architect-vscode"
+/>
+
 The `architect.yml` file contains the component descriptors that power Architect
 deployments. Why don't you open up the file in the react-app example:
 

--- a/home.mdx
+++ b/home.mdx
@@ -12,6 +12,11 @@ injected, dependant services are also built and deployed and accessible, all
 while giving you access to deploy logs and the ability to easily roll back a
 deployment if something goes wrong.
 
+<Card
+  title="For users of Visual Studio Code, check out the Architect.io extension!"
+  href="https://marketplace.visualstudio.com/items?itemName=Architectio.architect-vscode"
+/>
+
 ## Latest Blog Posts
 
 <Card


### PR DESCRIPTION
Note - I believe the reference/architect.yml  page is generated by the CLI still, so I'll be updating that too to add an extension link too.