### PR TITLE
Interpolation docs

### DIFF
--- a/getting-started/best-practices.mdx
+++ b/getting-started/best-practices.mdx
@@ -79,6 +79,11 @@ them at deployment time. This applies to both
 [service](/components/service-discovery) and
 [dependency](/components/dependencies) references.
 
+## Interpolation
+
+Architect component configuration files are meant to be used to deploy applications to any environment, whether that's local or remote.
+Because of this, things that can change between environments such as service addresses and secrets should be referenced by [interpolation](/reference/contexts-and-interpolation#interpolation).
+
 ## Volumes
 
 Volumes are important in local and production-grade deployments to persist data

--- a/getting-started/introduction.mdx
+++ b/getting-started/introduction.mdx
@@ -90,7 +90,7 @@ https://app.localhost.architect.sh:443/ => react
 ```
 You'll notice in the output above that one or more URLs are provided, depending on your starter project.
 For example, starter projects with a frontend will be accessible at `https://app.localhost.architect.sh:443/` as
-soon as the startup completes. 
+soon as the startup completes.
 
 When you run the command above, Architect reads the `architect.yml` file in the repo and transforms it into
 a fully enriched `docker-compose.yml` file. The application described in this file is run automatically in your local
@@ -111,7 +111,7 @@ are working with.
   href="https://marketplace.visualstudio.com/items?itemName=Architectio.architect-vscode"
 />
 
-```
+```yml
 name: react
 
 description: |

--- a/mint.json
+++ b/mint.json
@@ -105,7 +105,7 @@
       "pages": [
         "reference/release-notes",
         "reference/changelog",
-        "reference/contexts",
+        "reference/contexts-and-interpolation",
         "reference/architect-yml",
         "reference/templates",
         "reference/cli"

--- a/reference/architect-yml.mdx
+++ b/reference/architect-yml.mdx
@@ -4,7 +4,7 @@ title: architect.yml
 
 # architect.yml
 
-This document describes the full specification of the [architect.yml](https://docs.architect.io/components/architect-yml) configuration file. The top level of your `architect.yml` should be a [ComponentSpec](#componentspec).
+This document describes the full specification of the [architect.yml](/components/architect-yml) configuration file. The top level of your `architect.yml` should be a [ComponentSpec](#componentspec).
 
 We've published a formal definition of this specification here: [Architect JSONSchema](https://raw.githubusercontent.com/architect-team/architect-cli/main/src/dependency-manager/schema/architect.schema.json).
 
@@ -49,20 +49,20 @@ A runtimes (e.g. daemons, servers, etc.). Each service is independently deployab
  | `interfaces` | Dict&lt;string&gt; | A set of named interfaces to expose service functionality over the network to other services within the same component. A `string` or `number` represents the TCP port that the service is listening on. For more detailed configuration, specify a full `ServiceInterfaceSpec` object. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F!-)(%3F!.%7B0%2C32%7D--)%5Ba-z0-9-%5D%7B1%2C32%7D(%3F%3C!-)%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>,  |
  | `liveness_probe` | [LivenessProbeSpec](#livenessprobespec) |  |  |
  | `volumes` | Dict&lt;string&gt; | A set of named volumes to be mounted at deploy-time. Take advantage of volumes to store data that should be shared between running containers or that should persist beyond the lifetime of a container. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F!-)(%3F!.%7B0%2C32%7D--)%5Ba-z0-9-%5D%7B1%2C32%7D(%3F%3C!-)%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>,  |
- | `replicas` | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A static number of replicas of a service to be deployed. For scaling configuration, see `scaling` field. |  |
+ | `replicas` | integer \| [Expression](/reference/contexts-and-interpolation) | A static number of replicas of a service to be deployed. For scaling configuration, see `scaling` field. |  |
  | `scaling` | [ScalingSpec](#scalingspec) |  |  |
  | `deploy` | [DeploySpec](#deployspec) |  |  |
  | `description` | string | Human readable description |  |
- | `image` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker image that serves as the unit of runtime. This field is disjunctive with `build` (only one of `image` or `build` can be set) |  |
- | `command` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker startup command. Use this if you need to override or parameterize or parameterize the docker image command. |  |
- | `entrypoint` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker entrypoint for the container. Use this if you need to override or parameterize the docker image entrypoint. |  |
+ | `image` | string \| [Expression](/reference/contexts-and-interpolation) | The docker image that serves as the unit of runtime. This field is disjunctive with `build` (only one of `image` or `build` can be set) |  |
+ | `command` | Array&lt;string&gt; \| string \| [Expression](/reference/contexts-and-interpolation) | The docker startup command. Use this if you need to override or parameterize or parameterize the docker image command. |  |
+ | `entrypoint` | Array&lt;string&gt; \| string \| [Expression](/reference/contexts-and-interpolation) | The docker entrypoint for the container. Use this if you need to override or parameterize the docker image entrypoint. |  |
  | `language` | string | The dominant programming language used; this is for informational purposes only. |  |
- | `environment` | Dict&lt;string&gt; | A set of key-value pairs or secret definitions that describes environment variables and their values. | <a target="_blank" href="https://regexr.com/?expression=%5E%5Ba-zA-Z0-9_%5D%2B%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](https://docs.architect.io/components/services/#local-configuration) |
+ | `environment` | Dict&lt;string&gt; | A set of key-value pairs or secret definitions that describes environment variables and their values. | <a target="_blank" href="https://regexr.com/?expression=%5E%5Ba-zA-Z0-9_%5D%2B%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](/components/services/#local-configuration) |
  | `build` | [BuildSpec](#buildspec) |  |  |
- | `cpu` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The cpu required to run a service or a task | [More](https://docs.architect.io/components/services/#cpu--memory) |
- | `memory` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The memory required to run a service or a task. | [More](https://docs.architect.io/components/services/#cpu--memory) |
+ | `cpu` | number \| [Expression](/reference/contexts-and-interpolation) | The cpu required to run a service or a task | [More](/components/services/#cpu--memory) |
+ | `memory` | string \| [Expression](/reference/contexts-and-interpolation) | The memory required to run a service or a task. | [More](/components/services/#cpu--memory) |
  | `depends_on` | Array&lt;string&gt; | An array of service names for those services in the component that are pre-requisites to deploy. Used at deploy-time to build a deploy order across services and tasks. |  |
- | `labels` | Dict&lt;string&gt; | A simple key-value annotation store; useful to organize, categorize, scope, and select services and tasks. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F%3D(.%7B1%2C63%7D%2F)%3F.%7B1%2C63%7D%24)(((%5Ba-z0-9%5D%5B-a-z0-9_.%5D*)%3F%5Ba-z0-9%5D)%3F%2F)%3F((%5BA-Za-z0-9%5D%5B-A-Za-z0-9_.%5D*)%3F%5BA-Za-z0-9%5D)%3F%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](https://docs.architect.io/components/services/#labels) |
+ | `labels` | Dict&lt;string&gt; | A simple key-value annotation store; useful to organize, categorize, scope, and select services and tasks. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F%3D(.%7B1%2C63%7D%2F)%3F.%7B1%2C63%7D%24)(((%5Ba-z0-9%5D%5B-a-z0-9_.%5D*)%3F%5Ba-z0-9%5D)%3F%2F)%3F((%5BA-Za-z0-9%5D%5B-A-Za-z0-9_.%5D*)%3F%5BA-Za-z0-9%5D)%3F%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](/components/services/#labels) |
  | `reserved_name` | string | A specific service name which will override the service name specified in the component. | Must match: <a target="_blank" href="https://regexr.com/?expression=%5E(%3F!-)(%3F!.%7B0%2C32%7D--)%5Ba-z0-9-%5D%7B1%2C32%7D(%3F%3C!-)%24">Regex</a> |
 
 
@@ -74,7 +74,7 @@ Components can define configurable secrets that can be used to enrich the contai
 | -------------------- | ---------- | -------------- | -------------- |
  | `required` | boolean | Denotes whether the secret is required. |  |
  | `description` | string | A human-friendly description of the secret. |  |
- | `default` | Array&lt;any&gt; \| boolean \| number \| object \| string \| null \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Sets a default value for the secret if one is not provided |  |
+ | `default` | Array&lt;any&gt; \| boolean \| number \| object \| string \| null \| [Expression](/reference/contexts-and-interpolation) | Sets a default value for the secret if one is not provided |  |
 
 
 ## ComponentInterfaceSpec
@@ -86,12 +86,12 @@ Component Interfaces are the primary means by which components advertise their r
  | `ingress` | [IngressSpec](#ingressspec) |  |  |
  | `description` | string | A human-readable description of the component. This will be rendered when potential consumers view the interface so that they know what it should be used for. |  |
  | `host` | string | The host that the component interface should forward to. |  |
- | `port` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The port that the component interface should forward to. |  |
- | `protocol` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The protocol by which the component interface can be connected to. |  |
- | `username` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The Basic Auth username by which a component interface can be connected to. |  |
- | `password` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The Basic Auth password by which a component interface can be connected to. |  |
- | `url`* | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The url that the component interface should forward to. |  |
- | `sticky` | boolean \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | If this interface is made into an external ingress, sticky=true will denote the gateway should use sticky sessions if more than one replica is running. |  |
+ | `port` | number \| [Expression](/reference/contexts-and-interpolation) | The port that the component interface should forward to. |  |
+ | `protocol` | string \| [Expression](/reference/contexts-and-interpolation) | The protocol by which the component interface can be connected to. |  |
+ | `username` | string \| [Expression](/reference/contexts-and-interpolation) | The Basic Auth username by which a component interface can be connected to. |  |
+ | `password` | string \| [Expression](/reference/contexts-and-interpolation) | The Basic Auth password by which a component interface can be connected to. |  |
+ | `url`* | string \| [Expression](/reference/contexts-and-interpolation) | The url that the component interface should forward to. |  |
+ | `sticky` | boolean \| [Expression](/reference/contexts-and-interpolation) | If this interface is made into an external ingress, sticky=true will denote the gateway should use sticky sessions if more than one replica is running. |  |
 
 
 ## TaskSpec
@@ -101,18 +101,18 @@ A Task represents a recurring and/or exiting runtime (e.g. crons, schedulers, tr
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
  | `debug` | Partial&lt;[TaskSpec](#taskspec)&gt; | A partial object that is deep-merged into the spec on local deployments. Useful to mount developer volumes or set other local-development configuration. Think of this as a "local override" block. |  |
- | `schedule` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A cron expression by which this task will be scheduled. Leave blank to deploy a task that never runs unless triggered from the CLI. |  |
+ | `schedule` | string \| [Expression](/reference/contexts-and-interpolation) | A cron expression by which this task will be scheduled. Leave blank to deploy a task that never runs unless triggered from the CLI. |  |
  | `description` | string | Human readable description |  |
- | `image` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker image that serves as the unit of runtime. This field is disjunctive with `build` (only one of `image` or `build` can be set) |  |
- | `command` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker startup command. Use this if you need to override or parameterize or parameterize the docker image command. |  |
- | `entrypoint` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker entrypoint for the container. Use this if you need to override or parameterize the docker image entrypoint. |  |
+ | `image` | string \| [Expression](/reference/contexts-and-interpolation) | The docker image that serves as the unit of runtime. This field is disjunctive with `build` (only one of `image` or `build` can be set) |  |
+ | `command` | Array&lt;string&gt; \| string \| [Expression](/reference/contexts-and-interpolation) | The docker startup command. Use this if you need to override or parameterize or parameterize the docker image command. |  |
+ | `entrypoint` | Array&lt;string&gt; \| string \| [Expression](/reference/contexts-and-interpolation) | The docker entrypoint for the container. Use this if you need to override or parameterize the docker image entrypoint. |  |
  | `language` | string | The dominant programming language used; this is for informational purposes only. |  |
- | `environment` | Dict&lt;string&gt; | A set of key-value pairs or secret definitions that describes environment variables and their values. | <a target="_blank" href="https://regexr.com/?expression=%5E%5Ba-zA-Z0-9_%5D%2B%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](https://docs.architect.io/components/services/#local-configuration) |
+ | `environment` | Dict&lt;string&gt; | A set of key-value pairs or secret definitions that describes environment variables and their values. | <a target="_blank" href="https://regexr.com/?expression=%5E%5Ba-zA-Z0-9_%5D%2B%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](/components/services/#local-configuration) |
  | `build` | [BuildSpec](#buildspec) |  |  |
- | `cpu` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The cpu required to run a service or a task | [More](https://docs.architect.io/components/services/#cpu--memory) |
- | `memory` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The memory required to run a service or a task. | [More](https://docs.architect.io/components/services/#cpu--memory) |
+ | `cpu` | number \| [Expression](/reference/contexts-and-interpolation) | The cpu required to run a service or a task | [More](/components/services/#cpu--memory) |
+ | `memory` | string \| [Expression](/reference/contexts-and-interpolation) | The memory required to run a service or a task. | [More](/components/services/#cpu--memory) |
  | `depends_on` | Array&lt;string&gt; | An array of service names for those services in the component that are pre-requisites to deploy. Used at deploy-time to build a deploy order across services and tasks. |  |
- | `labels` | Dict&lt;string&gt; | A simple key-value annotation store; useful to organize, categorize, scope, and select services and tasks. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F%3D(.%7B1%2C63%7D%2F)%3F.%7B1%2C63%7D%24)(((%5Ba-z0-9%5D%5B-a-z0-9_.%5D*)%3F%5Ba-z0-9%5D)%3F%2F)%3F((%5BA-Za-z0-9%5D%5B-A-Za-z0-9_.%5D*)%3F%5BA-Za-z0-9%5D)%3F%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](https://docs.architect.io/components/services/#labels) |
+ | `labels` | Dict&lt;string&gt; | A simple key-value annotation store; useful to organize, categorize, scope, and select services and tasks. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F%3D(.%7B1%2C63%7D%2F)%3F.%7B1%2C63%7D%24)(((%5Ba-z0-9%5D%5B-a-z0-9_.%5D*)%3F%5Ba-z0-9%5D)%3F%2F)%3F((%5BA-Za-z0-9%5D%5B-A-Za-z0-9_.%5D*)%3F%5BA-Za-z0-9%5D)%3F%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](/components/services/#labels) |
  | `reserved_name` | string | A specific service name which will override the service name specified in the component. | Must match: <a target="_blank" href="https://regexr.com/?expression=%5E(%3F!-)(%3F!.%7B0%2C32%7D--)%5Ba-z0-9-%5D%7B1%2C32%7D(%3F%3C!-)%24">Regex</a> |
 
 
@@ -123,8 +123,8 @@ Component databases let you quickly spin up a database for your service
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
  | `description` | string | Human readable description |  |
- | `type`* | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The type engine and version of database software needed for data storage. |  |
- | `connection_string` | string \| null \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The connection uri of an existing database to use instead of provisioning a new one |  |
+ | `type`* | string \| [Expression](/reference/contexts-and-interpolation) | The type engine and version of database software needed for data storage. |  |
+ | `connection_string` | string \| null \| [Expression](/reference/contexts-and-interpolation) | The connection uri of an existing database to use instead of provisioning a new one |  |
 
 
 ## LivenessProbeSpec
@@ -133,14 +133,14 @@ Configuration for service health checks. Architect uses health checks are used f
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `success_threshold` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The number of times to retry a health check before the container is considered healthy. | default: `1` |
- | `failure_threshold` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The number of times to retry a failed health check before the container is considered unhealthy. | default: `3` |
- | `timeout` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between: 2s and 60s | default: `5s` |
- | `interval` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The time period in seconds between each health check execution. You may specify any value between: 5s and 300s | default: `30s` |
- | `initial_delay` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Delays the check from running for the specified amount of time | default: `0s` |
- | ~~`path`~~ | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | [Deprecated: use `command` instead.] Path for the http check executable. Path should be absolute (e.g. /health). If `path` is set, `port` also must be set. This field is disjunctive with `command` (only one of `path` or `command` can be set). | Deprecated |
+ | `success_threshold` | number \| [Expression](/reference/contexts-and-interpolation) | The number of times to retry a health check before the container is considered healthy. | default: `1` |
+ | `failure_threshold` | number \| [Expression](/reference/contexts-and-interpolation) | The number of times to retry a failed health check before the container is considered unhealthy. | default: `3` |
+ | `timeout` | string \| [Expression](/reference/contexts-and-interpolation) | The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between: 2s and 60s | default: `5s` |
+ | `interval` | string \| [Expression](/reference/contexts-and-interpolation) | The time period in seconds between each health check execution. You may specify any value between: 5s and 300s | default: `30s` |
+ | `initial_delay` | string \| [Expression](/reference/contexts-and-interpolation) | Delays the check from running for the specified amount of time | default: `0s` |
+ | ~~`path`~~ | string \| [Expression](/reference/contexts-and-interpolation) | [Deprecated: use `command` instead.] Path for the http check executable. Path should be absolute (e.g. /health). If `path` is set, `port` also must be set. This field is disjunctive with `command` (only one of `path` or `command` can be set). | Deprecated |
  | `command` | Array&lt;string&gt; \| string | Command that runs the http check. This field is disjunctive with `path` and `port` (only one of `command` or `path`/`port` can be set). |  |
- | ~~`port`~~ | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | [Deprecated: use `command` instead.] Port that the http check will run against. If `port` is set, `path` also must be set. This field is disjunctive with `command` (only one of `port` or `command` can be set). | Deprecated |
+ | ~~`port`~~ | number \| [Expression](/reference/contexts-and-interpolation) | [Deprecated: use `command` instead.] Port that the http check will run against. If `port` is set, `path` also must be set. This field is disjunctive with `command` (only one of `port` or `command` can be set). | Deprecated |
 
 
 ## VolumeSpec
@@ -149,11 +149,11 @@ Architect can mount volumes onto your services and tasks to store data that shou
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `mount_path` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Directory at which the volume will be mounted inside the container. |  |
- | `host_path` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A directory on the host machine to sync with the mount_path on the docker image. This field is only relevant inside the debug block for local deployments. This field is disjunctive with `key` (only one of `host_path` or `key` can be set). |  |
- | `key` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A reference to the underlying volume on the deployment cluster of choice. The `docker-compose` volume name, the name of the Kubernetes PersistentVolumeClaim, or the EFS ID of an AWS volume. This field is disjunctive with `host_path` (only one of `key` or `host_path` can be set). | [More](https://docs.architect.io/components/services/#volumes) |
+ | `mount_path` | string \| [Expression](/reference/contexts-and-interpolation) | Directory at which the volume will be mounted inside the container. |  |
+ | `host_path` | string \| [Expression](/reference/contexts-and-interpolation) | A directory on the host machine to sync with the mount_path on the docker image. This field is only relevant inside the debug block for local deployments. This field is disjunctive with `key` (only one of `host_path` or `key` can be set). |  |
+ | `key` | string \| [Expression](/reference/contexts-and-interpolation) | A reference to the underlying volume on the deployment cluster of choice. The `docker-compose` volume name, the name of the Kubernetes PersistentVolumeClaim, or the EFS ID of an AWS volume. This field is disjunctive with `host_path` (only one of `key` or `host_path` can be set). | [More](/components/services/#volumes) |
  | `description` | string | Human-readable description of volume |  |
- | `readonly` | boolean \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Marks the volume as readonly. |  |
+ | `readonly` | boolean \| [Expression](/reference/contexts-and-interpolation) | Marks the volume as readonly. |  |
 
 
 ## BuildSpec
@@ -162,11 +162,11 @@ An object containing the details necessary for Architect to build the service vi
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `context` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The path to the directory containing the source code relative to the `architect.yml` file. |  |
+ | `context` | string \| [Expression](/reference/contexts-and-interpolation) | The path to the directory containing the source code relative to the `architect.yml` file. |  |
  | `buildpack` | boolean | Option to use buildpack to build an image. |  |
  | `args` | Dict&lt;string&gt; | Build args to be passed into `docker build`. | <a target="_blank" href="https://regexr.com/?expression=%5E%5Ba-zA-Z0-9_%5D%2B%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>,  |
- | `dockerfile` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The path to the Dockerfile relative to the `build.context` | default: `Dockerfile` |
- | `target` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The stage to build in the Dockerfile |  |
+ | `dockerfile` | string \| [Expression](/reference/contexts-and-interpolation) | The path to the Dockerfile relative to the `build.context` | default: `Dockerfile` |
+ | `target` | string \| [Expression](/reference/contexts-and-interpolation) | The stage to build in the Dockerfile |  |
 
 
 ## IngressSpec
@@ -176,9 +176,9 @@ An ingress exposes an interface to external network traffic through an architect
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
  | `enabled` | boolean | Marks the interface as an ingress. |  |
- | `subdomain` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The subdomain that will be used if the interface is exposed externally. Use `subdomain: @` to target the base domain. |  |
- | `path` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The path of the interface used for path based routing |  |
- | `ip_whitelist` | Array&lt;string \| string&gt; \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | IP addresses that are allowed to access the interface |  |
+ | `subdomain` | string \| [Expression](/reference/contexts-and-interpolation) | The subdomain that will be used if the interface is exposed externally. Use `subdomain: @` to target the base domain. |  |
+ | `path` | string \| [Expression](/reference/contexts-and-interpolation) | The path of the interface used for path based routing |  |
+ | `ip_whitelist` | Array&lt;string \| string&gt; \| [Expression](/reference/contexts-and-interpolation) | IP addresses that are allowed to access the interface |  |
 
 
 ## ScalingMetricsSpec
@@ -187,8 +187,8 @@ Scaling metrics define the upper bound of resource consumption before spinning u
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `cpu` | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The cpu usage required to trigger scaling. | [More](https://docs.architect.io/components/services/#cpu--memory) |
- | `memory` | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The memory usage required to trigger scaling. | [More](https://docs.architect.io/components/services/#cpu--memory) |
+ | `cpu` | integer \| [Expression](/reference/contexts-and-interpolation) | The cpu usage required to trigger scaling. | [More](/components/services/#cpu--memory) |
+ | `memory` | integer \| [Expression](/reference/contexts-and-interpolation) | The memory usage required to trigger scaling. | [More](/components/services/#cpu--memory) |
 
 
 ## ScalingSpec
@@ -197,8 +197,8 @@ Configuration that dictates the scaling behavior of a service.
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `min_replicas`* | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The target minimum number of service replicas. |  |
- | `max_replicas`* | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The target maximum number of service replicas. |  |
+ | `min_replicas`* | integer \| [Expression](/reference/contexts-and-interpolation) | The target minimum number of service replicas. |  |
+ | `max_replicas`* | integer \| [Expression](/reference/contexts-and-interpolation) | The target maximum number of service replicas. |  |
  | `metrics`* | [ScalingMetricsSpec](#scalingmetricsspec) |  |  |
 
 
@@ -226,15 +226,15 @@ A service interface exposes service functionality over the network to other serv
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `description` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A human-readable description of the interface. |  |
- | `host` | null \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The host address of an existing service to use instead of provisioning a new one. Setting this field effectively overrides any deployment of this service and directs all traffic to the given host. |  |
- | `port`* | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Port on which the service is listening for traffic. |  |
- | `protocol` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Protocol that the interface responds to | default: `http` |
- | `username` | null \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A Basic Auth username required to access the interface |  |
- | `password` | null \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A Basic Auth password required to access the interface |  |
- | `path` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The path of the interface |  |
- | `url` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The url of an existing service to use instead of provisioning a new one. Setting this field effectively overrides any deployment of this service and directs all traffic to the given url. |  |
- | `sticky` | boolean \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Denotes that if this interface is made external, the gateway should use sticky sessions |  |
+ | `description` | string \| [Expression](/reference/contexts-and-interpolation) | A human-readable description of the interface. |  |
+ | `host` | null \| string \| [Expression](/reference/contexts-and-interpolation) | The host address of an existing service to use instead of provisioning a new one. Setting this field effectively overrides any deployment of this service and directs all traffic to the given host. |  |
+ | `port`* | number \| [Expression](/reference/contexts-and-interpolation) | Port on which the service is listening for traffic. |  |
+ | `protocol` | string \| [Expression](/reference/contexts-and-interpolation) | Protocol that the interface responds to | default: `http` |
+ | `username` | null \| string \| [Expression](/reference/contexts-and-interpolation) | A Basic Auth username required to access the interface |  |
+ | `password` | null \| string \| [Expression](/reference/contexts-and-interpolation) | A Basic Auth password required to access the interface |  |
+ | `path` | string \| [Expression](/reference/contexts-and-interpolation) | The path of the interface |  |
+ | `url` | string \| [Expression](/reference/contexts-and-interpolation) | The url of an existing service to use instead of provisioning a new one. Setting this field effectively overrides any deployment of this service and directs all traffic to the given url. |  |
+ | `sticky` | boolean \| [Expression](/reference/contexts-and-interpolation) | Denotes that if this interface is made external, the gateway should use sticky sessions |  |
  | `ingress` | [IngressSpec](#ingressspec) |  |  |
 
 

--- a/reference/architect-yml.mdx
+++ b/reference/architect-yml.mdx
@@ -49,18 +49,18 @@ A runtimes (e.g. daemons, servers, etc.). Each service is independently deployab
  | `interfaces` | Dict&lt;string&gt; | A set of named interfaces to expose service functionality over the network to other services within the same component. A `string` or `number` represents the TCP port that the service is listening on. For more detailed configuration, specify a full `ServiceInterfaceSpec` object. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F!-)(%3F!.%7B0%2C32%7D--)%5Ba-z0-9-%5D%7B1%2C32%7D(%3F%3C!-)%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>,  |
  | `liveness_probe` | [LivenessProbeSpec](#livenessprobespec) |  |  |
  | `volumes` | Dict&lt;string&gt; | A set of named volumes to be mounted at deploy-time. Take advantage of volumes to store data that should be shared between running containers or that should persist beyond the lifetime of a container. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F!-)(%3F!.%7B0%2C32%7D--)%5Ba-z0-9-%5D%7B1%2C32%7D(%3F%3C!-)%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>,  |
- | `replicas` | integer \| [Expression](https://docs.architect.io/reference/contexts) | A static number of replicas of a service to be deployed. For scaling configuration, see `scaling` field. |  |
+ | `replicas` | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A static number of replicas of a service to be deployed. For scaling configuration, see `scaling` field. |  |
  | `scaling` | [ScalingSpec](#scalingspec) |  |  |
  | `deploy` | [DeploySpec](#deployspec) |  |  |
  | `description` | string | Human readable description |  |
- | `image` | string \| [Expression](https://docs.architect.io/reference/contexts) | The docker image that serves as the unit of runtime. This field is disjunctive with `build` (only one of `image` or `build` can be set) |  |
- | `command` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts) | The docker startup command. Use this if you need to override or parameterize or parameterize the docker image command. |  |
- | `entrypoint` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts) | The docker entrypoint for the container. Use this if you need to override or parameterize the docker image entrypoint. |  |
+ | `image` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker image that serves as the unit of runtime. This field is disjunctive with `build` (only one of `image` or `build` can be set) |  |
+ | `command` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker startup command. Use this if you need to override or parameterize or parameterize the docker image command. |  |
+ | `entrypoint` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker entrypoint for the container. Use this if you need to override or parameterize the docker image entrypoint. |  |
  | `language` | string | The dominant programming language used; this is for informational purposes only. |  |
  | `environment` | Dict&lt;string&gt; | A set of key-value pairs or secret definitions that describes environment variables and their values. | <a target="_blank" href="https://regexr.com/?expression=%5E%5Ba-zA-Z0-9_%5D%2B%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](https://docs.architect.io/components/services/#local-configuration) |
  | `build` | [BuildSpec](#buildspec) |  |  |
- | `cpu` | number \| [Expression](https://docs.architect.io/reference/contexts) | The cpu required to run a service or a task | [More](https://docs.architect.io/components/services/#cpu--memory) |
- | `memory` | string \| [Expression](https://docs.architect.io/reference/contexts) | The memory required to run a service or a task. | [More](https://docs.architect.io/components/services/#cpu--memory) |
+ | `cpu` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The cpu required to run a service or a task | [More](https://docs.architect.io/components/services/#cpu--memory) |
+ | `memory` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The memory required to run a service or a task. | [More](https://docs.architect.io/components/services/#cpu--memory) |
  | `depends_on` | Array&lt;string&gt; | An array of service names for those services in the component that are pre-requisites to deploy. Used at deploy-time to build a deploy order across services and tasks. |  |
  | `labels` | Dict&lt;string&gt; | A simple key-value annotation store; useful to organize, categorize, scope, and select services and tasks. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F%3D(.%7B1%2C63%7D%2F)%3F.%7B1%2C63%7D%24)(((%5Ba-z0-9%5D%5B-a-z0-9_.%5D*)%3F%5Ba-z0-9%5D)%3F%2F)%3F((%5BA-Za-z0-9%5D%5B-A-Za-z0-9_.%5D*)%3F%5BA-Za-z0-9%5D)%3F%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](https://docs.architect.io/components/services/#labels) |
  | `reserved_name` | string | A specific service name which will override the service name specified in the component. | Must match: <a target="_blank" href="https://regexr.com/?expression=%5E(%3F!-)(%3F!.%7B0%2C32%7D--)%5Ba-z0-9-%5D%7B1%2C32%7D(%3F%3C!-)%24">Regex</a> |
@@ -74,7 +74,7 @@ Components can define configurable secrets that can be used to enrich the contai
 | -------------------- | ---------- | -------------- | -------------- |
  | `required` | boolean | Denotes whether the secret is required. |  |
  | `description` | string | A human-friendly description of the secret. |  |
- | `default` | Array&lt;any&gt; \| boolean \| number \| object \| string \| null \| [Expression](https://docs.architect.io/reference/contexts) | Sets a default value for the secret if one is not provided |  |
+ | `default` | Array&lt;any&gt; \| boolean \| number \| object \| string \| null \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Sets a default value for the secret if one is not provided |  |
 
 
 ## ComponentInterfaceSpec
@@ -86,12 +86,12 @@ Component Interfaces are the primary means by which components advertise their r
  | `ingress` | [IngressSpec](#ingressspec) |  |  |
  | `description` | string | A human-readable description of the component. This will be rendered when potential consumers view the interface so that they know what it should be used for. |  |
  | `host` | string | The host that the component interface should forward to. |  |
- | `port` | number \| [Expression](https://docs.architect.io/reference/contexts) | The port that the component interface should forward to. |  |
- | `protocol` | string \| [Expression](https://docs.architect.io/reference/contexts) | The protocol by which the component interface can be connected to. |  |
- | `username` | string \| [Expression](https://docs.architect.io/reference/contexts) | The Basic Auth username by which a component interface can be connected to. |  |
- | `password` | string \| [Expression](https://docs.architect.io/reference/contexts) | The Basic Auth password by which a component interface can be connected to. |  |
- | `url`* | string \| [Expression](https://docs.architect.io/reference/contexts) | The url that the component interface should forward to. |  |
- | `sticky` | boolean \| [Expression](https://docs.architect.io/reference/contexts) | If this interface is made into an external ingress, sticky=true will denote the gateway should use sticky sessions if more than one replica is running. |  |
+ | `port` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The port that the component interface should forward to. |  |
+ | `protocol` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The protocol by which the component interface can be connected to. |  |
+ | `username` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The Basic Auth username by which a component interface can be connected to. |  |
+ | `password` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The Basic Auth password by which a component interface can be connected to. |  |
+ | `url`* | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The url that the component interface should forward to. |  |
+ | `sticky` | boolean \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | If this interface is made into an external ingress, sticky=true will denote the gateway should use sticky sessions if more than one replica is running. |  |
 
 
 ## TaskSpec
@@ -101,16 +101,16 @@ A Task represents a recurring and/or exiting runtime (e.g. crons, schedulers, tr
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
  | `debug` | Partial&lt;[TaskSpec](#taskspec)&gt; | A partial object that is deep-merged into the spec on local deployments. Useful to mount developer volumes or set other local-development configuration. Think of this as a "local override" block. |  |
- | `schedule` | string \| [Expression](https://docs.architect.io/reference/contexts) | A cron expression by which this task will be scheduled. Leave blank to deploy a task that never runs unless triggered from the CLI. |  |
+ | `schedule` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A cron expression by which this task will be scheduled. Leave blank to deploy a task that never runs unless triggered from the CLI. |  |
  | `description` | string | Human readable description |  |
- | `image` | string \| [Expression](https://docs.architect.io/reference/contexts) | The docker image that serves as the unit of runtime. This field is disjunctive with `build` (only one of `image` or `build` can be set) |  |
- | `command` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts) | The docker startup command. Use this if you need to override or parameterize or parameterize the docker image command. |  |
- | `entrypoint` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts) | The docker entrypoint for the container. Use this if you need to override or parameterize the docker image entrypoint. |  |
+ | `image` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker image that serves as the unit of runtime. This field is disjunctive with `build` (only one of `image` or `build` can be set) |  |
+ | `command` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker startup command. Use this if you need to override or parameterize or parameterize the docker image command. |  |
+ | `entrypoint` | Array&lt;string&gt; \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The docker entrypoint for the container. Use this if you need to override or parameterize the docker image entrypoint. |  |
  | `language` | string | The dominant programming language used; this is for informational purposes only. |  |
  | `environment` | Dict&lt;string&gt; | A set of key-value pairs or secret definitions that describes environment variables and their values. | <a target="_blank" href="https://regexr.com/?expression=%5E%5Ba-zA-Z0-9_%5D%2B%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](https://docs.architect.io/components/services/#local-configuration) |
  | `build` | [BuildSpec](#buildspec) |  |  |
- | `cpu` | number \| [Expression](https://docs.architect.io/reference/contexts) | The cpu required to run a service or a task | [More](https://docs.architect.io/components/services/#cpu--memory) |
- | `memory` | string \| [Expression](https://docs.architect.io/reference/contexts) | The memory required to run a service or a task. | [More](https://docs.architect.io/components/services/#cpu--memory) |
+ | `cpu` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The cpu required to run a service or a task | [More](https://docs.architect.io/components/services/#cpu--memory) |
+ | `memory` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The memory required to run a service or a task. | [More](https://docs.architect.io/components/services/#cpu--memory) |
  | `depends_on` | Array&lt;string&gt; | An array of service names for those services in the component that are pre-requisites to deploy. Used at deploy-time to build a deploy order across services and tasks. |  |
  | `labels` | Dict&lt;string&gt; | A simple key-value annotation store; useful to organize, categorize, scope, and select services and tasks. | <a target="_blank" href="https://regexr.com/?expression=%5E(%3F%3D(.%7B1%2C63%7D%2F)%3F.%7B1%2C63%7D%24)(((%5Ba-z0-9%5D%5B-a-z0-9_.%5D*)%3F%5Ba-z0-9%5D)%3F%2F)%3F((%5BA-Za-z0-9%5D%5B-A-Za-z0-9_.%5D*)%3F%5BA-Za-z0-9%5D)%3F%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>, [More](https://docs.architect.io/components/services/#labels) |
  | `reserved_name` | string | A specific service name which will override the service name specified in the component. | Must match: <a target="_blank" href="https://regexr.com/?expression=%5E(%3F!-)(%3F!.%7B0%2C32%7D--)%5Ba-z0-9-%5D%7B1%2C32%7D(%3F%3C!-)%24">Regex</a> |
@@ -123,8 +123,8 @@ Component databases let you quickly spin up a database for your service
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
  | `description` | string | Human readable description |  |
- | `type`* | string \| [Expression](https://docs.architect.io/reference/contexts) | The type engine and version of database software needed for data storage. |  |
- | `connection_string` | string \| null \| [Expression](https://docs.architect.io/reference/contexts) | The connection uri of an existing database to use instead of provisioning a new one |  |
+ | `type`* | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The type engine and version of database software needed for data storage. |  |
+ | `connection_string` | string \| null \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The connection uri of an existing database to use instead of provisioning a new one |  |
 
 
 ## LivenessProbeSpec
@@ -133,14 +133,14 @@ Configuration for service health checks. Architect uses health checks are used f
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `success_threshold` | number \| [Expression](https://docs.architect.io/reference/contexts) | The number of times to retry a health check before the container is considered healthy. | default: `1` |
- | `failure_threshold` | number \| [Expression](https://docs.architect.io/reference/contexts) | The number of times to retry a failed health check before the container is considered unhealthy. | default: `3` |
- | `timeout` | string \| [Expression](https://docs.architect.io/reference/contexts) | The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between: 2s and 60s | default: `5s` |
- | `interval` | string \| [Expression](https://docs.architect.io/reference/contexts) | The time period in seconds between each health check execution. You may specify any value between: 5s and 300s | default: `30s` |
- | `initial_delay` | string \| [Expression](https://docs.architect.io/reference/contexts) | Delays the check from running for the specified amount of time | default: `0s` |
- | ~~`path`~~ | string \| [Expression](https://docs.architect.io/reference/contexts) | [Deprecated: use `command` instead.] Path for the http check executable. Path should be absolute (e.g. /health). If `path` is set, `port` also must be set. This field is disjunctive with `command` (only one of `path` or `command` can be set). | Deprecated |
+ | `success_threshold` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The number of times to retry a health check before the container is considered healthy. | default: `1` |
+ | `failure_threshold` | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The number of times to retry a failed health check before the container is considered unhealthy. | default: `3` |
+ | `timeout` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between: 2s and 60s | default: `5s` |
+ | `interval` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The time period in seconds between each health check execution. You may specify any value between: 5s and 300s | default: `30s` |
+ | `initial_delay` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Delays the check from running for the specified amount of time | default: `0s` |
+ | ~~`path`~~ | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | [Deprecated: use `command` instead.] Path for the http check executable. Path should be absolute (e.g. /health). If `path` is set, `port` also must be set. This field is disjunctive with `command` (only one of `path` or `command` can be set). | Deprecated |
  | `command` | Array&lt;string&gt; \| string | Command that runs the http check. This field is disjunctive with `path` and `port` (only one of `command` or `path`/`port` can be set). |  |
- | ~~`port`~~ | number \| [Expression](https://docs.architect.io/reference/contexts) | [Deprecated: use `command` instead.] Port that the http check will run against. If `port` is set, `path` also must be set. This field is disjunctive with `command` (only one of `port` or `command` can be set). | Deprecated |
+ | ~~`port`~~ | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | [Deprecated: use `command` instead.] Port that the http check will run against. If `port` is set, `path` also must be set. This field is disjunctive with `command` (only one of `port` or `command` can be set). | Deprecated |
 
 
 ## VolumeSpec
@@ -149,11 +149,11 @@ Architect can mount volumes onto your services and tasks to store data that shou
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `mount_path` | string \| [Expression](https://docs.architect.io/reference/contexts) | Directory at which the volume will be mounted inside the container. |  |
- | `host_path` | string \| [Expression](https://docs.architect.io/reference/contexts) | A directory on the host machine to sync with the mount_path on the docker image. This field is only relevant inside the debug block for local deployments. This field is disjunctive with `key` (only one of `host_path` or `key` can be set). |  |
- | `key` | string \| [Expression](https://docs.architect.io/reference/contexts) | A reference to the underlying volume on the deployment cluster of choice. The `docker-compose` volume name, the name of the Kubernetes PersistentVolumeClaim, or the EFS ID of an AWS volume. This field is disjunctive with `host_path` (only one of `key` or `host_path` can be set). | [More](https://docs.architect.io/components/services/#volumes) |
+ | `mount_path` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Directory at which the volume will be mounted inside the container. |  |
+ | `host_path` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A directory on the host machine to sync with the mount_path on the docker image. This field is only relevant inside the debug block for local deployments. This field is disjunctive with `key` (only one of `host_path` or `key` can be set). |  |
+ | `key` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A reference to the underlying volume on the deployment cluster of choice. The `docker-compose` volume name, the name of the Kubernetes PersistentVolumeClaim, or the EFS ID of an AWS volume. This field is disjunctive with `host_path` (only one of `key` or `host_path` can be set). | [More](https://docs.architect.io/components/services/#volumes) |
  | `description` | string | Human-readable description of volume |  |
- | `readonly` | boolean \| [Expression](https://docs.architect.io/reference/contexts) | Marks the volume as readonly. |  |
+ | `readonly` | boolean \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Marks the volume as readonly. |  |
 
 
 ## BuildSpec
@@ -162,11 +162,11 @@ An object containing the details necessary for Architect to build the service vi
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `context` | string \| [Expression](https://docs.architect.io/reference/contexts) | The path to the directory containing the source code relative to the `architect.yml` file. |  |
+ | `context` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The path to the directory containing the source code relative to the `architect.yml` file. |  |
  | `buildpack` | boolean | Option to use buildpack to build an image. |  |
  | `args` | Dict&lt;string&gt; | Build args to be passed into `docker build`. | <a target="_blank" href="https://regexr.com/?expression=%5E%5Ba-zA-Z0-9_%5D%2B%24">KeyRegex</a>, <a target="_blank" href="https://regexr.com/?expression=undefined">ValueRegex</a>,  |
- | `dockerfile` | string \| [Expression](https://docs.architect.io/reference/contexts) | The path to the Dockerfile relative to the `build.context` | default: `Dockerfile` |
- | `target` | string \| [Expression](https://docs.architect.io/reference/contexts) | The stage to build in the Dockerfile |  |
+ | `dockerfile` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The path to the Dockerfile relative to the `build.context` | default: `Dockerfile` |
+ | `target` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The stage to build in the Dockerfile |  |
 
 
 ## IngressSpec
@@ -176,9 +176,9 @@ An ingress exposes an interface to external network traffic through an architect
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
  | `enabled` | boolean | Marks the interface as an ingress. |  |
- | `subdomain` | string \| [Expression](https://docs.architect.io/reference/contexts) | The subdomain that will be used if the interface is exposed externally. Use `subdomain: @` to target the base domain. |  |
- | `path` | string \| [Expression](https://docs.architect.io/reference/contexts) | The path of the interface used for path based routing |  |
- | `ip_whitelist` | Array&lt;string \| string&gt; \| [Expression](https://docs.architect.io/reference/contexts) | IP addresses that are allowed to access the interface |  |
+ | `subdomain` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The subdomain that will be used if the interface is exposed externally. Use `subdomain: @` to target the base domain. |  |
+ | `path` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The path of the interface used for path based routing |  |
+ | `ip_whitelist` | Array&lt;string \| string&gt; \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | IP addresses that are allowed to access the interface |  |
 
 
 ## ScalingMetricsSpec
@@ -187,8 +187,8 @@ Scaling metrics define the upper bound of resource consumption before spinning u
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `cpu` | integer \| [Expression](https://docs.architect.io/reference/contexts) | The cpu usage required to trigger scaling. | [More](https://docs.architect.io/components/services/#cpu--memory) |
- | `memory` | integer \| [Expression](https://docs.architect.io/reference/contexts) | The memory usage required to trigger scaling. | [More](https://docs.architect.io/components/services/#cpu--memory) |
+ | `cpu` | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The cpu usage required to trigger scaling. | [More](https://docs.architect.io/components/services/#cpu--memory) |
+ | `memory` | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The memory usage required to trigger scaling. | [More](https://docs.architect.io/components/services/#cpu--memory) |
 
 
 ## ScalingSpec
@@ -197,8 +197,8 @@ Configuration that dictates the scaling behavior of a service.
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `min_replicas`* | integer \| [Expression](https://docs.architect.io/reference/contexts) | The target minimum number of service replicas. |  |
- | `max_replicas`* | integer \| [Expression](https://docs.architect.io/reference/contexts) | The target maximum number of service replicas. |  |
+ | `min_replicas`* | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The target minimum number of service replicas. |  |
+ | `max_replicas`* | integer \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The target maximum number of service replicas. |  |
  | `metrics`* | [ScalingMetricsSpec](#scalingmetricsspec) |  |  |
 
 
@@ -226,15 +226,15 @@ A service interface exposes service functionality over the network to other serv
 
 | Field  (*=required)  | Type       | Description    | Misc           |
 | -------------------- | ---------- | -------------- | -------------- |
- | `description` | string \| [Expression](https://docs.architect.io/reference/contexts) | A human-readable description of the interface. |  |
- | `host` | null \| string \| [Expression](https://docs.architect.io/reference/contexts) | The host address of an existing service to use instead of provisioning a new one. Setting this field effectively overrides any deployment of this service and directs all traffic to the given host. |  |
- | `port`* | number \| [Expression](https://docs.architect.io/reference/contexts) | Port on which the service is listening for traffic. |  |
- | `protocol` | string \| [Expression](https://docs.architect.io/reference/contexts) | Protocol that the interface responds to | default: `http` |
- | `username` | null \| string \| [Expression](https://docs.architect.io/reference/contexts) | A Basic Auth username required to access the interface |  |
- | `password` | null \| string \| [Expression](https://docs.architect.io/reference/contexts) | A Basic Auth password required to access the interface |  |
- | `path` | string \| [Expression](https://docs.architect.io/reference/contexts) | The path of the interface |  |
- | `url` | string \| [Expression](https://docs.architect.io/reference/contexts) | The url of an existing service to use instead of provisioning a new one. Setting this field effectively overrides any deployment of this service and directs all traffic to the given url. |  |
- | `sticky` | boolean \| [Expression](https://docs.architect.io/reference/contexts) | Denotes that if this interface is made external, the gateway should use sticky sessions |  |
+ | `description` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A human-readable description of the interface. |  |
+ | `host` | null \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The host address of an existing service to use instead of provisioning a new one. Setting this field effectively overrides any deployment of this service and directs all traffic to the given host. |  |
+ | `port`* | number \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Port on which the service is listening for traffic. |  |
+ | `protocol` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Protocol that the interface responds to | default: `http` |
+ | `username` | null \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A Basic Auth username required to access the interface |  |
+ | `password` | null \| string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | A Basic Auth password required to access the interface |  |
+ | `path` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The path of the interface |  |
+ | `url` | string \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | The url of an existing service to use instead of provisioning a new one. Setting this field effectively overrides any deployment of this service and directs all traffic to the given url. |  |
+ | `sticky` | boolean \| [Expression](https://docs.architect.io/reference/contexts-and-interpolation) | Denotes that if this interface is made external, the gateway should use sticky sessions |  |
  | `ingress` | [IngressSpec](#ingressspec) |  |  |
 
 

--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -4,7 +4,7 @@ Architect is the world's first [DevOps-as-a-Service](https://architect.io/produc
 
 Our unique approach to continuous delivery is powered by an embedded dependency resolver. By simply asserting your microservice dependenies, Architect is able to build a graph of your application and deploy the entire stack to your favorite cloud provider.
 
-Architect's CLI, which provides the full developer experience needed to create [components](https://docs.architect.io) and operate local [environments](https://docs.architect.io/deployments/local-environments), is fully open-source. The CLI can deploy components locally using docker-compose, enrich the deployments with components found in Architect's Cloud registry, and allows developers to publish their own components to the registry both publicly and privately for free.
+Architect's CLI, which provides the full developer experience needed to create [components](/guides/create-a-component) and operate local [environments](/deployments/local-environments), is fully open-source. The CLI can deploy components locally using docker-compose, enrich the deployments with components found in Architect's Cloud registry, and allows developers to publish their own components to the registry both publicly and privately for free.
 
 ## Requirements
 * [**Docker**](https://docs.docker.com/get-docker/) must be installed

--- a/reference/contexts-and-interpolation.mdx
+++ b/reference/contexts-and-interpolation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Contexts"
+title: "Contexts and Interpolation"
 ---
 
 When writing `architect.yml files`, you can reference information about the
@@ -42,7 +42,7 @@ interfaces.
 | Property                | Type     | Description                                                                                                                                |
 | ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `ingresses`             | `object` | Information on the ingress rules of the component                                                                                          |
-| `ingresses.<interface>` | `object` | Information on an ingress rule matching the interface. [See the interface values](/reference/contexts/#interface-values) for more details. |
+| `ingresses.<interface>` | `object` | Information on an ingress rule matching the interface. [See the interface values](/reference/contexts-and-interpolation/#interface-values) for more details. |
 
 ### `secrets` context
 
@@ -81,3 +81,156 @@ Interface values are referenced in many places, `dependencies` and `services` wi
 | host     | The host value of the interface being referenced. This value is usually dynamic to accomodate the differences between service discovery solutions available to each environment.                                                                                |
 | port     | The port value of the interface being referenced. This will not always be the specific port that the interface is listening on as many container clusters leverage port mapping to ensure that there are no port collisions when sharing hardware in a cluster. |
 | path     | The path value of the interface being referenced. Not all interfaces have paths, so this will be an empty string if none is set.                                                                                                                                |                                                                                                                         |
+
+## Interpolation
+
+Interpolation is used in the `architect.yml` component configuration file to reference values in contexts defined by Architect.
+Common use cases for interpolation include referencing the address of another service within the component, the address of a dependent component,
+a secret of the component, an ingress of a service, and more. An interpolation reference always starts with `${{` and ends with `}}`.
+When the component is started with either [`architect dev`](/reference/cli#architect-dev-configs-or-components) or [`architect deploy`](/reference/cli#architect-deploy-configs-or-components),
+any interpolation references in the component file will be populated with real values.
+
+### Examples of common use cases
+
+#### Referencing the address of a dependency
+
+In certain cases, a component will reference another Architect component as a dependency, and an address of a service within that dependency will need to be referenced.
+Take the following example of two components, where the "api" component is a dependency of the "app" component.
+
+```yml
+# architect.yml of the api component
+name: api
+
+services:
+  api:
+    interfaces:
+      main:
+        port: 8080
+        ingress:
+          subdomain: api
+...
+```
+
+```yml
+# architect.yml of the app component
+name: app
+
+dependencies:
+  api: latest
+
+services:
+  app:
+    environment:
+      API_ADDRESS: ${{ dependencies.api.services.api.interfaces.main.ingress.url }}
+...
+```
+
+#### Referencing a secret
+
+Secrets will frequently be defined in the component configuration file and will be populated when the component is started. It will then be referenced in a part of a service,
+such as the environment block.
+
+```yml
+# architect.yml
+name: app
+
+secrets:
+  api_key:
+
+services:
+  app:
+    environment:
+      API_KEY: ${{ secrets.api_key }}
+...
+```
+
+#### Referencing the internal address of another service
+
+Services within the same component will often need to reference one another within the same network.
+In the example below, the "app" service references the internal address of the "api" service.
+
+```yml
+# architect.yml
+name: my-component
+
+services:
+  app:
+    environment:
+      API_ADDRESS: ${{ services.api.interfaces.main.url }}
+
+  api:
+    interfaces:
+      main:
+        port: 8080
+...
+```
+
+#### Referencing the external address of another service
+
+Services within the same component will sometimes need to reference one another from outside of the network. This is common when a frontend application needs to make calls to an API from
+a browser. In the example below, the "app" service references the external, public-facing address of the "api" service.
+
+```yml
+# architect.yml
+name: my-component
+
+services:
+  app:
+    environment:
+      API_ADDRESS: ${{ services.api.interfaces.main.ingress.url }}
+
+  api:
+    interfaces:
+      main:
+        port: 8080
+        ingress:
+          subdomain: api
+...
+```
+
+### Example of a simple component with interpolation
+
+The following example component uses the Docker image built by our "node-rest-api" [example project](https://github.com/architect-templates/node-rest-api) and connects the API to a Postgres database.
+`${{ services.database.interfaces.main.url }}` is used to allow the database to connect to the API. When the component is started, the interpolation reference will be replaced by an automatically-generated
+network address where the database service can be reached. Secrets are passed to each service with secret interpolation such as `${{ secrets.db_name }}`. The secret interpolation references
+will be replaced by actual secret values when the component is started.
+
+```yml
+# architect.yml
+name: api-example
+
+secrets:
+  db_user:
+    default: architect
+  db_pass:
+    default: secret
+  db_name:
+    default: api-db
+
+services:
+  # Application service
+  api:
+    image: registry.gitlab.com/architect-io/docker-files/sample-backend:latest
+    interfaces:
+      main:
+        port: 8080
+        ingress:
+          subdomain: api
+    environment:
+      DB_ADDR: ${{ services.database.interfaces.main.url }}/${{ secrets.db_name }}
+      DB_USER: ${{ secrets.db_user }}
+      DB_PASS: ${{ secrets.db_pass }}
+      PORT: 8080
+
+  # Database service
+  database:
+    image: postgres:12
+    interfaces:
+      main:
+        port: 5432
+        protocol: postgresql
+    environment:
+      POSTGRES_USER: ${{ secrets.db_user }}
+      POSTGRES_PASSWORD: ${{ secrets.db_pass }}
+      POSTGRES_DB: ${{ secrets.db_name }}
+```

--- a/reference/contexts-and-interpolation.mdx
+++ b/reference/contexts-and-interpolation.mdx
@@ -2,7 +2,7 @@
 title: "Contexts and Interpolation"
 ---
 
-When writing `architect.yml files`, you can reference information about the
+When writing `architect.yml` files, you can reference information about the
 runtime or environment, details that are otherwise unique to each deployed
 environment, through Architect's expression syntax. Encoding component's with
 these references can help limit the manual configuration needs of your services
@@ -87,47 +87,14 @@ Interface values are referenced in many places, `dependencies` and `services` wi
 Interpolation is used in the `architect.yml` component configuration file to reference values in contexts defined by Architect.
 Common use cases for interpolation include referencing the address of another service within the component, the address of a dependent component,
 a secret of the component, an ingress of a service, and more. An interpolation reference always starts with `${{` and ends with `}}`.
-When the component is started with either [`architect dev`](/reference/cli#architect-dev-configs-or-components) or [`architect deploy`](/reference/cli#architect-deploy-configs-or-components),
+When the component is deployed with either [`architect dev`](/reference/cli#architect-dev-configs-or-components) or [`architect deploy`](/reference/cli#architect-deploy-configs-or-components),
 any interpolation references in the component file will be populated with real values.
 
 ### Examples of common use cases
 
-#### Referencing the address of a dependency
-
-In certain cases, a component will reference another Architect component as a dependency, and an address of a service within that dependency will need to be referenced.
-Take the following example of two components, where the "api" component is a dependency of the "app" component.
-
-```yml
-# architect.yml of the api component
-name: api
-
-services:
-  api:
-    interfaces:
-      main:
-        port: 8080
-        ingress:
-          subdomain: api
-...
-```
-
-```yml
-# architect.yml of the app component
-name: app
-
-dependencies:
-  api: latest
-
-services:
-  app:
-    environment:
-      API_ADDRESS: ${{ dependencies.api.services.api.interfaces.main.ingress.url }}
-...
-```
-
 #### Referencing a secret
 
-Secrets will frequently be defined in the component configuration file and will be populated when the component is started. It will then be referenced in a part of a service,
+Secrets will frequently be defined in the component configuration file and will be populated when the component is deployed. It will then be referenced in a part of a service,
 such as the environment block.
 
 ```yml
@@ -167,8 +134,9 @@ services:
 
 #### Referencing the external address of another service
 
-Services within the same component will sometimes need to reference one another from outside of the network. This is common when a frontend application needs to make calls to an API from
-a browser. In the example below, the "app" service references the external, public-facing address of the "api" service.
+Services within the same component will sometimes need to reference one another from outside of the network. A common case is when a frontend application needs to make calls to an
+API from a browser. In the example below, the "app" service references the external, public-facing address of the "api" service. The external address of the API service is generated
+automatically by Architect when the component is deployed.
 
 ```yml
 # architect.yml
@@ -188,12 +156,45 @@ services:
 ...
 ```
 
+#### Referencing the address of a dependency
+
+In certain cases, a component will reference another Architect component as a dependency, and an address of a service within that dependency will need to be referenced.
+Take the following example of two components, where the "api" component is a dependency of the "app" component.
+
+```yml
+# architect.yml of the api component
+name: api
+
+services:
+  api:
+    interfaces:
+      main:
+        port: 8080
+        ingress:
+          subdomain: api
+...
+```
+
+```yml
+# architect.yml of the app component
+name: app
+
+dependencies:
+  api: latest
+
+services:
+  app:
+    environment:
+      API_ADDRESS: ${{ dependencies.api.services.api.interfaces.main.ingress.url }}
+...
+```
+
 ### Example of a simple component with interpolation
 
 The following example component uses the Docker image built by our "node-rest-api" [example project](https://github.com/architect-templates/node-rest-api) and connects the API to a Postgres database.
-`${{ services.database.interfaces.main.url }}` is used to allow the database to connect to the API. When the component is started, the interpolation reference will be replaced by an automatically-generated
+`${{ services.database.interfaces.main.url }}` is used to allow the database to connect to the API. When the component is deployed, the interpolation reference will be replaced by an automatically-generated
 network address where the database service can be reached. Secrets are passed to each service with secret interpolation such as `${{ secrets.db_name }}`. The secret interpolation references
-will be replaced by actual secret values when the component is started.
+will be replaced by actual secret values when the component is deployed.
 
 ```yml
 # architect.yml


### PR DESCRIPTION
## Purpose 
Closes https://gitlab.com/architect-io/product/-/issues/233

## Changes
* Updated codeblock with no type to `yml`
* Updated `/contexts` to be `/contexts-and-interpolation`
* Updated broken link
* Updated some links to remove the hardcoded `https://docs.architect.io`
* Added interpolation section with common examples and a full working example