### PR TITLE
updates to gitlab ci flow after testing

### DIFF
--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -218,7 +218,6 @@ destroy_preview:
     action: stop
   rules:
     - if: $CI_MERGE_REQUEST_ID
-      allow_failure: true
       when: manual
     - if: $CI_MERGE_REQUEST_APPROVED
 

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -154,9 +154,8 @@ jobs:
 ### Creating and cleaning up preview environments
 
 This job can be pasted into your `.gitlab-ci.yml` at the root of your repository. You are welcome to change the `stage` to whatever fits your needs to allow you to run
-tests before the preview is generated, and please be sure to assign correct values for the variables in the job.
-Additionally, you'll need to assign values for variables in the below config not prefixed with `$CI_` in your repository's CI variables configuration so that
-the architect commands will run successfully.
+tests before the preview is generated. Please be sure to assign correct values for the variables in the job marked with `<set-this-as-a-CI/CD-variable>` as well as the
+ones mentioned in the warning below.
 
 This configuration takes advantage of GitLab environments in order to give you better control and visibility into what environments exist and what's deployed to them.
 On PR creation, both a GitLab and Architect environment will be created. The component specified in the repository will be registered with the Architect Cloud and
@@ -164,7 +163,7 @@ deployed to the environment. When the PR is either merged or closed, the GitLab 
 in the Architect Cloud will be destroyed.
 
 <Warning>
-  This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables
+  This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
 </Warning>
 
 <Warning>

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -151,9 +151,15 @@ jobs:
 
 ## Gitlab CI
 
+### Creating and cleaning up preview environments
+
 This job can be pasted into your `.gitlab-ci.yml` at the root of your repository. You are welcome to change the `stage` to whatever fits your needs to allow you to run tests before the preview is generated, and please be sure to assign correct values for the variables in the job. Additionally, you'll need to assign values for variables in the below config not prefixed with `$CI_` in your repository's CI variables configuration so that the architect commands will run successfully.
 
 This configuration takes advantage of GitLab environments in order to give you better control and visibility into what environments exist and what's deployed to them. On PR creation, both a GitLab and Architect environment will be created. The component specified in the repository will be registered with the Architect Cloud and deployed to the environment. When the PR is either merged or closed, the GitLab environment will be automatically deleted and the component deployed to the environment in the Architect Cloud will be destroyed.
+
+<Warning>
+  This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables
+</Warning>
 
 <Warning>
   `ARCHITECT_PASSWORD` must be a [personal access
@@ -161,13 +167,12 @@ This configuration takes advantage of GitLab environments in order to give you b
 </Warning>
 
 ```yaml
-# this example assumes that the repo has ARCHITECT_ACCOUNT and ARCHITECT_CLUSTER set as CI/CD variables
 stages:
   - preview
 
 variables:
-  ARCHITECT_ACCOUNT: <account-name>
-  ARCHITECT_CLUSTER: <cluster-name>
+  ARCHITECT_ACCOUNT: <set-this-as-a-CI/CD-variable>
+  ARCHITECT_CLUSTER: <set-this-as-a-CI/CD-variable>
   ARCHITECT_ENVIRONMENT: preview-$CI_MERGE_REQUEST_ID
 
 default:
@@ -185,7 +190,7 @@ deploy_preview:
   stage: preview
   script: |
     architect environment:create $ARCHITECT_ENVIRONMENT --cluster $ARCHITECT_CLUSTER
-    architect deploy architect.yml --auto-approve --environment $ARCHITECT_ENVIRONMENT
+    architect deploy architect.yml --environment $ARCHITECT_ENVIRONMENT --auto-approve
   environment:
     name: architect/preview-$CI_MERGE_REQUEST_ID
     url: https://cloud.architect.io/$ARCHITECT_ACCOUNT/environments/preview-$CI_MERGE_REQUEST_ID/
@@ -198,12 +203,14 @@ destroy_preview:
   variables:
     ARCHITECT_ENVIRONMENT: preview-$CI_MERGE_REQUEST_ID
   script: |
-    architect destroy --auto-approve --environment $ARCHITECT_ENVIRONMENT
-    architect environment:destroy --auto-approve $ARCHITECT_ENVIRONMENT
+    architect destroy --environment $ARCHITECT_ENVIRONMENT --auto-approve
+    architect environment:destroy $ARCHITECT_ENVIRONMENT --auto-approve
   environment:
     name: architect/preview-$CI_MERGE_REQUEST_ID
     action: stop
   rules:
     - if: $CI_MERGE_REQUEST_ID
+      allow_failure: true
       when: manual
+    - if: $CI_MERGE_REQUEST_APPROVED
 ```

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -168,7 +168,7 @@ in the Architect Cloud will be destroyed.
 
 <Warning>
   `ARCHITECT_PASSWORD` must be a [personal access
-  token](https://cloud.architect.io/login).
+  token](/deployments/personal-access-tokens).
 </Warning>
 
 ```yaml

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -13,10 +13,10 @@ What this means is that not only can developers run the stack privately, but the
 
 The workflow below can be pasted into a file in your repository in the `.github/workflows` folder to trigger automated preview environments via Architect. These previews will be created whenever a pull request is submitted that targets the master branch. Be sure to set values in Github Secrets for the architect fields: `ARCHITECT_EMAIL` and `ARCHITECT_PASSWORD`. Replace `<account-name>`, `<cluster-name>` with the appropriate values.
 
-<Warning>
+<Note>
   `ARCHITECT_PASSWORD` must be a [personal access
-  token](https://cloud.architect.io/login).
-</Warning>
+  token](/deployments/personal-access-tokens).
+</Note>
 
 ```yaml
 name: Architect Preview
@@ -166,10 +166,10 @@ in the Architect Cloud will be destroyed.
   This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
 </Warning>
 
-<Warning>
+<Note>
   `ARCHITECT_PASSWORD` must be a [personal access
   token](/deployments/personal-access-tokens).
-</Warning>
+</Note>
 
 ```yaml
 stages:

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -11,10 +11,10 @@ What this means is that not only can developers run the stack privately, but the
 
 ### Create preview environment
 
-The workflow below can be pasted into a file in your repository in the `.github/workflows` folder to trigger automated preview environments via Architect. These previews will be created whenever a pull request is submitted that targets the master branch. Be sure to set values in Github Secrets for the architect fields: `ARCHITECT_EMAIL` and `ARCHITECT_PASSWORD`. Replace `<account-name>`, `<cluster-name>` with the appropriate values.
+The workflow below can be pasted into a file in your repository in the `.github/workflows` folder to trigger automated preview environments via Architect. These previews will be created whenever a pull request is submitted that targets the master branch. Be sure to set values in Github Secrets for the architect fields: `ARCHITECT_EMAIL` and `ARCHITECT_PAT`. Replace `<account-name>`, `<cluster-name>` with the appropriate values.
 
 <Note>
-  `ARCHITECT_PASSWORD` must be a [personal access
+  `ARCHITECT_PAT` must be a [personal access
   token](/deployments/personal-access-tokens).
 </Note>
 
@@ -30,7 +30,7 @@ on:
 
 env:
   ARCHITECT_EMAIL: ${{ secrets.ARCHITECT_EMAIL }}
-  ARCHITECT_PASSWORD: ${{ secrets.ARCHITECT_PASSWORD }}
+  ARCHITECT_PAT: ${{ secrets.ARCHITECT_PAT }}
   ARCHITECT_ACCOUNT: <account-name>
 
 jobs:
@@ -89,7 +89,7 @@ on:
 
 env:
   ARCHITECT_EMAIL: ${{ secrets.ARCHITECT_EMAIL }}
-  ARCHITECT_PASSWORD: ${{ secrets.ARCHITECT_PASSWORD }}
+  ARCHITECT_PAT: ${{ secrets.ARCHITECT_PAT }}
   ARCHITECT_ACCOUNT: reach-demo
 
 jobs:
@@ -163,11 +163,11 @@ deployed to the environment. When the PR is either merged or closed, the GitLab 
 in the Architect Cloud will be destroyed.
 
 <Note>
-  This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
+  This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PAT`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
 </Note>
 
 <Note>
-  `ARCHITECT_PASSWORD` must be a [personal access
+  `ARCHITECT_PAT` must be a [personal access
   token](/deployments/personal-access-tokens).
 </Note>
 

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -155,16 +155,16 @@ jobs:
 
 This job can be pasted into your `.gitlab-ci.yml` at the root of your repository. You are welcome to change the `stage` to whatever fits your needs to allow you to run
 tests before the preview is generated. Please be sure to assign correct values for the variables in the job marked with `<set-this-as-a-CI/CD-variable>` as well as the
-ones mentioned in the warning below.
+ones mentioned in the note below.
 
 This configuration takes advantage of GitLab environments in order to give you better control and visibility into what environments exist and what's deployed to them.
 On PR creation, both a GitLab and Architect environment will be created. The component specified in the repository will be registered with the Architect Cloud and
 deployed to the environment. When the PR is either merged or closed, the GitLab environment will be automatically deleted and the component deployed to the environment
 in the Architect Cloud will be destroyed.
 
-<Warning>
+<Note>
   This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
-</Warning>
+</Note>
 
 <Note>
   `ARCHITECT_PASSWORD` must be a [personal access

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -189,7 +189,7 @@ variables:
   before_script:
     - apk add --update npm
     - npm install -g @architect-io/cli
-    - architect login -e $ARCHITECT_EMAIL -p $ARCHITECT_PASSWORD
+    - architect login
 
 deploy_preview:
   <<: *preview_common

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -153,9 +153,15 @@ jobs:
 
 ### Creating and cleaning up preview environments
 
-This job can be pasted into your `.gitlab-ci.yml` at the root of your repository. You are welcome to change the `stage` to whatever fits your needs to allow you to run tests before the preview is generated, and please be sure to assign correct values for the variables in the job. Additionally, you'll need to assign values for variables in the below config not prefixed with `$CI_` in your repository's CI variables configuration so that the architect commands will run successfully.
+This job can be pasted into your `.gitlab-ci.yml` at the root of your repository. You are welcome to change the `stage` to whatever fits your needs to allow you to run
+tests before the preview is generated, and please be sure to assign correct values for the variables in the job.
+Additionally, you'll need to assign values for variables in the below config not prefixed with `$CI_` in your repository's CI variables configuration so that
+the architect commands will run successfully.
 
-This configuration takes advantage of GitLab environments in order to give you better control and visibility into what environments exist and what's deployed to them. On PR creation, both a GitLab and Architect environment will be created. The component specified in the repository will be registered with the Architect Cloud and deployed to the environment. When the PR is either merged or closed, the GitLab environment will be automatically deleted and the component deployed to the environment in the Architect Cloud will be destroyed.
+This configuration takes advantage of GitLab environments in order to give you better control and visibility into what environments exist and what's deployed to them.
+On PR creation, both a GitLab and Architect environment will be created. The component specified in the repository will be registered with the Architect Cloud and
+deployed to the environment. When the PR is either merged or closed, the GitLab environment will be automatically deleted and the component deployed to the environment
+in the Architect Cloud will be destroyed.
 
 <Warning>
   This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables
@@ -174,43 +180,47 @@ variables:
   ARCHITECT_ACCOUNT: <set-this-as-a-CI/CD-variable>
   ARCHITECT_CLUSTER: <set-this-as-a-CI/CD-variable>
   ARCHITECT_ENVIRONMENT: preview-$CI_MERGE_REQUEST_ID
+  ARCHITECT_CACHE_DIR: .architect-cache/
 
-default:
-  image: docker:latest
+.preview_common: &preview_common
+  image: docker:23.0.1
   services:
-    - docker:dind
+    - docker:23.0.1-dind
   before_script:
-    - apk add --update npm git
-    - apk add yq --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
-    # Install architect cli and login
+    - apk add --update npm
     - npm install -g @architect-io/cli
     - architect login -e $ARCHITECT_EMAIL -p $ARCHITECT_PASSWORD
 
 deploy_preview:
+  <<: *preview_common
   stage: preview
-  script: |
-    architect environment:create $ARCHITECT_ENVIRONMENT --cluster $ARCHITECT_CLUSTER
-    architect deploy architect.yml --environment $ARCHITECT_ENVIRONMENT --auto-approve
+  timeout: 1h
+  script:
+    - architect environment:create "${ARCHITECT_ENVIRONMENT}" --description="https://gitlab.com/${CI_MERGE_REQUEST_PROJECT_PATH}/-/merge_requests/${CI_MERGE_REQUEST_IID}"
+    - architect deploy ./architect.yml --auto-approve --cache-directory=$ARCHITECT_CACHE_DIR
   environment:
-    name: architect/preview-$CI_MERGE_REQUEST_ID
-    url: https://cloud.architect.io/$ARCHITECT_ACCOUNT/environments/preview-$CI_MERGE_REQUEST_ID/
+    name: $ARCHITECT_ACCOUNT/preview-$CI_MERGE_REQUEST_IID
     on_stop: destroy_preview
   rules:
-    - if: $CI_MERGE_REQUEST_ID
+    - if: $CI_MERGE_REQUEST_IID
+  cache:
+    key: architect-preview-cache-$CI_COMMIT_REF_SLUG
+    paths:
+      - $ARCHITECT_CACHE_DIR
 
 destroy_preview:
+  <<: *preview_common
   stage: preview
-  variables:
-    ARCHITECT_ENVIRONMENT: preview-$CI_MERGE_REQUEST_ID
-  script: |
-    architect destroy --environment $ARCHITECT_ENVIRONMENT --auto-approve
-    architect environment:destroy $ARCHITECT_ENVIRONMENT --auto-approve
+  script:
+    - architect destroy --auto-approve
+    - architect environment:destroy "${ARCHITECT_ENVIRONMENT}" --auto-approve
   environment:
-    name: architect/preview-$CI_MERGE_REQUEST_ID
+    name: $ARCHITECT_ACCOUNT/preview-$CI_MERGE_REQUEST_IID
     action: stop
   rules:
     - if: $CI_MERGE_REQUEST_ID
       allow_failure: true
       when: manual
     - if: $CI_MERGE_REQUEST_APPROVED
+
 ```


### PR DESCRIPTION
## Purpose
Updates to the GitLab CI example

## Changes
* Adds an extra warning for CI variables
* Pins `dind` image version
* Adds caching for image on deployments
* Allows failure for the destroy job
* Deletes the component and environment when the PR is approved