### PR TITLE
adding bitbucket preview pipeline

### DIFF
--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -224,7 +224,7 @@ which should be done once the pull request is merged or closed.
 
 <Warning>
   `ARCHITECT_PASSWORD` must be a [personal access
-  token](https://cloud.architect.io/login).
+  token](/deployments/personal-access-tokens).
 </Warning>
 
 ```yml

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -11,10 +11,10 @@ What this means is that not only can developers run the stack privately, but the
 
 ### Create preview environment
 
-The workflow below can be pasted into a file in your repository in the `.github/workflows` folder to trigger automated preview environments via Architect. These previews will be created whenever a pull request is submitted that targets the master branch. Be sure to set values in Github Secrets for the architect fields: `ARCHITECT_EMAIL` and `ARCHITECT_PASSWORD`. Replace `<account-name>`, `<cluster-name>` with the appropriate values.
+The workflow below can be pasted into a file in your repository in the `.github/workflows` folder to trigger automated preview environments via Architect. These previews will be created whenever a pull request is submitted that targets the master branch. Be sure to set values in Github Secrets for the architect fields: `ARCHITECT_EMAIL` and `ARCHITECT_PAT`. Replace `<account-name>`, `<cluster-name>` with the appropriate values.
 
 <Note>
-  `ARCHITECT_PASSWORD` must be a [personal access
+  `ARCHITECT_PAT` must be a [personal access
   token](/deployments/personal-access-tokens).
 </Note>
 
@@ -30,7 +30,7 @@ on:
 
 env:
   ARCHITECT_EMAIL: ${{ secrets.ARCHITECT_EMAIL }}
-  ARCHITECT_PASSWORD: ${{ secrets.ARCHITECT_PASSWORD }}
+  ARCHITECT_PAT: ${{ secrets.ARCHITECT_PAT }}
   ARCHITECT_ACCOUNT: <account-name>
 
 jobs:
@@ -89,7 +89,7 @@ on:
 
 env:
   ARCHITECT_EMAIL: ${{ secrets.ARCHITECT_EMAIL }}
-  ARCHITECT_PASSWORD: ${{ secrets.ARCHITECT_PASSWORD }}
+  ARCHITECT_PAT: ${{ secrets.ARCHITECT_PAT }}
   ARCHITECT_ACCOUNT: reach-demo
 
 jobs:
@@ -156,7 +156,7 @@ This job can be pasted into your `.gitlab-ci.yml` at the root of your repository
 This configuration takes advantage of GitLab environments in order to give you better control and visibility into what environments exist and what's deployed to them. On PR creation, both a GitLab and Architect environment will be created. The component specified in the repository will be registered with the Architect Cloud and deployed to the environment. When the PR is either merged or closed, the GitLab environment will be automatically deleted and the component deployed to the environment in the Architect Cloud will be destroyed.
 
 <Note>
-  `ARCHITECT_PASSWORD` must be a [personal access
+  `ARCHITECT_PAT` must be a [personal access
   token](/deployments/personal-access-tokens).
 </Note>
 
@@ -179,7 +179,7 @@ default:
     - apk add yq --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
     # Install architect cli and login
     - npm install -g @architect-io/cli
-    - architect login -e $ARCHITECT_EMAIL -p $ARCHITECT_PASSWORD
+    - architect login -e $ARCHITECT_EMAIL -p $ARCHITECT_PAT
 
 deploy_preview:
   stage: preview
@@ -219,11 +219,11 @@ deployed to the environment. The pipeline provides the option to remove the depl
 which should be done once the pull request is merged or closed.
 
 <Note>
-  This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
+  This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PAT`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
 </Note>
 
 <Note>
-  `ARCHITECT_PASSWORD` must be a [personal access
+  `ARCHITECT_PAT` must be a [personal access
   token](/deployments/personal-access-tokens).
 </Note>
 

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -212,15 +212,15 @@ destroy_preview:
 
 ### Creating and cleaning up preview environments
 
-This job can be pasted into your `bitbucket-pipelines.yml` at the root of your repository. Be sure to add repository variables for the ones mentioned in the warning below.
+This job can be pasted into your `bitbucket-pipelines.yml` at the root of your repository. Be sure to add repository variables for the ones mentioned in the note below.
 
 On pull request creation, an Architect environment will be created. The component specified in the repository will be registered with the Architect Cloud and
 deployed to the environment. The pipeline provides the option to remove the deployed component and its environment from the Architect Cloud manually,
 which should be done once the pull request is merged or closed.
 
-<Warning>
+<Note>
   This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
-</Warning>
+</Note>
 
 <Note>
   `ARCHITECT_PASSWORD` must be a [personal access

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -207,3 +207,51 @@ destroy_preview:
     - if: $CI_MERGE_REQUEST_ID
       when: manual
 ```
+
+## BitBucket Pipelines
+
+### Creating and cleaning up preview environments
+
+This job can be pasted into your `bitbucket-pipelines.yml` at the root of your repository. Be sure to add repository variables for the ones mentioned in the warning below.
+
+On pull request creation, an Architect environment will be created. The component specified in the repository will be registered with the Architect Cloud and
+deployed to the environment. The pipeline provides the option to remove the deployed component and its environment from the Architect Cloud manually,
+which should be done once the pull request is merged or closed.
+
+<Warning>
+  This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
+</Warning>
+
+<Warning>
+  `ARCHITECT_PASSWORD` must be a [personal access
+  token](https://cloud.architect.io/login).
+</Warning>
+
+```yml
+image: docker:23.0.1
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: 'Deploy preview'
+          services:
+            - docker
+          script:
+            - apk add --update npm
+            - npm install -g @architect-io/cli
+            - architect login
+            - architect environment:create preview-$BITBUCKET_PR_ID --description="https://bitbucket.com/$BITBUCKET_WORKSPACE/$BITBUCKET_REPO_SLUG/pull-requests/$BITBUCKET_PR_ID"
+            - architect deploy ./architect.yml --environment preview-$BITBUCKET_PR_ID --auto-approve
+      - step:
+          name: 'Destroy preview'
+          trigger: 'manual'
+          services:
+            - docker
+          script:
+            - apk add --update npm
+            - npm install -g @architect-io/cli
+            - architect login
+            - architect destroy --environment preview-$BITBUCKET_PR_ID --auto-approve
+            - architect environment:destroy preview-$BITBUCKET_PR_ID --auto-approve
+```

--- a/deployments/automated-previews.mdx
+++ b/deployments/automated-previews.mdx
@@ -13,10 +13,10 @@ What this means is that not only can developers run the stack privately, but the
 
 The workflow below can be pasted into a file in your repository in the `.github/workflows` folder to trigger automated preview environments via Architect. These previews will be created whenever a pull request is submitted that targets the master branch. Be sure to set values in Github Secrets for the architect fields: `ARCHITECT_EMAIL` and `ARCHITECT_PASSWORD`. Replace `<account-name>`, `<cluster-name>` with the appropriate values.
 
-<Warning>
+<Note>
   `ARCHITECT_PASSWORD` must be a [personal access
-  token](https://cloud.architect.io/login).
-</Warning>
+  token](/deployments/personal-access-tokens).
+</Note>
 
 ```yaml
 name: Architect Preview
@@ -155,10 +155,10 @@ This job can be pasted into your `.gitlab-ci.yml` at the root of your repository
 
 This configuration takes advantage of GitLab environments in order to give you better control and visibility into what environments exist and what's deployed to them. On PR creation, both a GitLab and Architect environment will be created. The component specified in the repository will be registered with the Architect Cloud and deployed to the environment. When the PR is either merged or closed, the GitLab environment will be automatically deleted and the component deployed to the environment in the Architect Cloud will be destroyed.
 
-<Warning>
+<Note>
   `ARCHITECT_PASSWORD` must be a [personal access
-  token](https://cloud.architect.io/login).
-</Warning>
+  token](/deployments/personal-access-tokens).
+</Note>
 
 ```yaml
 # this example assumes that the repo has ARCHITECT_ACCOUNT and ARCHITECT_CLUSTER set as CI/CD variables
@@ -222,10 +222,10 @@ which should be done once the pull request is merged or closed.
   This example assumes that the repo has `ARCHITECT_EMAIL`, `ARCHITECT_PASSWORD`, `ARCHITECT_ACCOUNT`, and `ARCHITECT_CLUSTER` set as CI/CD variables.
 </Warning>
 
-<Warning>
+<Note>
   `ARCHITECT_PASSWORD` must be a [personal access
   token](/deployments/personal-access-tokens).
-</Warning>
+</Note>
 
 ```yml
 image: docker:23.0.1
@@ -241,7 +241,7 @@ pipelines:
             - apk add --update npm
             - npm install -g @architect-io/cli
             - architect login
-            - architect environment:create preview-$BITBUCKET_PR_ID --description="https://bitbucket.com/$BITBUCKET_WORKSPACE/$BITBUCKET_REPO_SLUG/pull-requests/$BITBUCKET_PR_ID"
+            - architect environment:create preview-$BITBUCKET_PR_ID --description="https://bitbucket.com/$BITBUCKET_WORKSPACE/$BITBUCKET_REPO_SLUG/pull-requests/$BITBUCKET_PR_ID" --ttl=1d
             - architect deploy ./architect.yml --environment preview-$BITBUCKET_PR_ID --auto-approve
       - step:
           name: 'Destroy preview'
@@ -255,3 +255,7 @@ pipelines:
             - architect destroy --environment preview-$BITBUCKET_PR_ID --auto-approve
             - architect environment:destroy preview-$BITBUCKET_PR_ID --auto-approve
 ```
+
+<Note>
+  The [`--ttl`](/reference/cli#architect-environments-create-environment) flag is used here in order to clean up the environment automatically after one day because BitBucket doesn't have a feature to trigger a pipeline when a pull request is closed.
+</Note>


### PR DESCRIPTION
## Purpose
Closes https://gitlab.com/architect-io/product/-/issues/260

## Changes
* Adds section to docs for BitBucket pipeline
  * Does not include caching as that's a feature that users can only take advantage of with self-hosted runners - https://bitbucket.org/blog/faster-ci-builds-with-docker-remote-caching
  * BitBucket also doesn't currently offer a clean way to run a pipeline when a PR is closed/merged, so it's done manually here - https://jira.atlassian.com/browse/BCLOUD-13867